### PR TITLE
fix(sync-readmes): use --no-checkout instead of sparse-checkout for gitcode source

### DIFF
--- a/.github/workflows/sync-readmes.yml
+++ b/.github/workflows/sync-readmes.yml
@@ -72,9 +72,9 @@ jobs:
               local owner="${BASH_REMATCH[1]}" repo="${BASH_REMATCH[2]}"
               local branch="${BASH_REMATCH[3]}" path="${BASH_REMATCH[4]}"
               local tmp; tmp=$(mktemp -d)
-              if git clone --quiet --depth=1 --filter=blob:none --sparse \
+              if git clone --quiet --depth=1 --filter=blob:none --no-checkout \
                    --branch "$branch" "https://gitcode.com/${owner}/${repo}.git" "$tmp" \
-                 && git -C "$tmp" sparse-checkout set "$path" >/dev/null \
+                 && git -C "$tmp" checkout HEAD -- "$path" \
                  && [ -f "$tmp/$path" ]; then
                 cp "$tmp/$path" "$out"
                 rm -rf "$tmp"


### PR DESCRIPTION
## Summary
修复 [run 25837287308](https://github.com/ascend-gha-runners/sync-tools/actions/runs/25837287308/job/75915008840) 中下载 `raw.gitcode.com/Ascend/RAGSDK/...` 的二次失败。

PR #14 合入后，下载步骤换成了 git clone + sparse-checkout，但在 GHA `ubuntu-latest`（git 2.43）上报错：
```
fatal: 'docker/OVERVIEW.md' is not a directory; to treat it as a directory anyway, rerun with --skip-checks
```

## Root cause
新版 git 默认 sparse-checkout **cone 模式**，cone 模式只接受目录前缀，不接受文件路径。本地复现时使用的是较旧版本的 git（cone 未启用），所以在 PR #14 验证时未暴露。

## Fix
改用 `--no-checkout` clone + `git checkout HEAD -- <path>`：
- 不依赖 sparse-checkout 模式，新旧 git 都通过
- 配合 `--filter=blob:none`，仍然只在 checkout 时按需拉取目标文件的 blob，开销与之前相同

## Test plan
- [x] 在 `ubuntu:24.04`（git 2.43.0，与 GHA runner 一致）容器中复现旧写法报错，并验证新写法成功拉取 OVERVIEW.md（3953 字节）
- [x] YAML 语法通过
- [x] 合入后手动触发 `Sync READMEs to Registries` workflow，确认能成功推送到 quay.io/ascend/ragsdk