### PR TITLE
fix(sync-readmes): use QUAY_API_KEY and adapt tables for quay UI

### DIFF
--- a/.github/scripts/quay_md_adapt.py
+++ b/.github/scripts/quay_md_adapt.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Adapt markdown for quay.io's repository description renderer.
+
+quay.io's Information tab uses react-markdown, but the deployed build does not
+render GFM pipe tables — they collapse onto one line as literal text. Inline
+HTML <table> tags are also stripped because rehype-raw is not enabled. The only
+form that renders reliably is a plain bullet list, so we rewrite each pipe
+table to "*<header line>*" followed by one bullet per row.
+
+Usage: quay_md_adapt.py <input.md> <output.md>
+"""
+import re
+import sys
+import pathlib
+
+
+def parse_row(line: str) -> list[str]:
+    s = line.strip()
+    if s.startswith("|"):
+        s = s[1:]
+    if s.endswith("|"):
+        s = s[:-1]
+    return [c.strip() for c in re.split(r"(?<!\\)\|", s)]
+
+
+def is_separator(line: str) -> bool:
+    s = line.strip()
+    if not s.startswith("|"):
+        return False
+    cells = [c for c in parse_row(s) if c]
+    return bool(cells) and all(re.fullmatch(r":?-{3,}:?", c) for c in cells)
+
+
+def render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    headers = [h for h in headers if h]
+    if not headers:
+        return []
+    out = ["*" + " — ".join(headers) + "*", ""]
+    for row in rows:
+        cells = (row + [""] * len(headers))[: len(headers)]
+        if not any(cells):
+            continue
+        first, rest = cells[0], [c for c in cells[1:] if c]
+        line = f"- **{first}**" if first else "-"
+        if rest:
+            line += " — " + " — ".join(rest)
+        out.append(line)
+    out.append("")
+    return out
+
+
+def convert(md: str) -> str:
+    lines = md.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        if (
+            i + 1 < len(lines)
+            and lines[i].lstrip().startswith("|")
+            and is_separator(lines[i + 1])
+        ):
+            headers = parse_row(lines[i])
+            j = i + 2
+            rows: list[list[str]] = []
+            while j < len(lines) and lines[j].lstrip().startswith("|"):
+                rows.append(parse_row(lines[j]))
+                j += 1
+            out.extend(render_table(headers, rows))
+            i = j
+        else:
+            out.append(lines[i])
+            i += 1
+    return "\n".join(out)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("usage: quay_md_adapt.py <input.md> <output.md>", file=sys.stderr)
+        sys.exit(2)
+    src = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+    pathlib.Path(sys.argv[2]).write_text(convert(src), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/sync-readmes.yml
+++ b/.github/workflows/sync-readmes.yml
@@ -46,7 +46,7 @@ jobs:
           DOCKER_PASS__DOCKER_IO: ${{ secrets.DOCKERHUB_PWD }}
           DOCKER_USER__QUAY_IO: ${{ vars.QUAY_ASCEND_USER }}
           DOCKER_PASS__QUAY_IO: ${{ secrets.QUAY_ASCEND_PWD }}
-          APIKEY__QUAY_IO: ${{ secrets.QUAY_API_TOKEN != '' && secrets.QUAY_API_TOKEN || secrets.QUAY_ASCEND_PWD }}
+          APIKEY__QUAY_IO: ${{ secrets.QUAY_API_KEY }}
         run: |
           set -euo pipefail
 
@@ -98,6 +98,24 @@ jobs:
               continue
             fi
 
+            case "$dest" in
+              docker.io/*) provider_args=() ;;
+              quay.io/*)
+                provider_args=(--provider quay)
+                # quay's Information tab strips inline HTML and the deployed
+                # react-markdown build does not render GFM pipe tables, so
+                # rewrite tables into bullet lists before upload.
+                adapted="$WORK_DIR/readme-${total}.quay.md"
+                python3 .github/scripts/quay_md_adapt.py "$readme_file" "$adapted"
+                readme_file="$adapted"
+                ;;
+              *)
+                echo "❌ unsupported registry: $dest"
+                failed=$((failed + 1))
+                continue
+                ;;
+            esac
+
             new_hash=$(sha256sum "$readme_file" | awk '{print $1}')
             cache_key=$(echo "$dest" | tr '/:' '__')
             cache_file="$CACHE_DIR/${cache_key}.hash"
@@ -106,16 +124,6 @@ jobs:
               skipped=$((skipped + 1))
               continue
             fi
-
-            case "$dest" in
-              docker.io/*) provider_args=() ;;
-              quay.io/*)   provider_args=(--provider quay) ;;
-              *)
-                echo "❌ unsupported registry: $dest"
-                failed=$((failed + 1))
-                continue
-                ;;
-            esac
 
             set +e
             docker-pushrm "${provider_args[@]}" --file "$readme_file" "$dest"


### PR DESCRIPTION
## Summary

- 把 `APIKEY__QUAY_IO` 改读 `secrets.QUAY_API_KEY`。之前引用的 `QUAY_API_TOKEN` 不存在，会 fallback 到 robot 账号密码 `QUAY_ASCEND_PWD`，但 quay 的 description API 不接受 robot 密码，返回 403。所需 token scope：**Administer Repositories**。
- 新增 `.github/scripts/quay_md_adapt.py`：把 GFM pipe table 改写成 bullet 列表。**仅对 `quay.io/*` 目标启用**，dockerhub 继续推送原文。
- cache 的 sha256 改为对**最终上传**的文件计算（quay 用转换后版本，dockerhub 用原文），dockerhub 和 quay 互不影响。

## Why

quay.io Information tab 用的是 `react-markdown` + `remark-gfm` ([Information.tsx](https://github.com/quay/quay/blob/master/web/src/routes/RepositoryDetails/Information/Information.tsx))，但当前线上部署的版本对 GFM pipe table 没有真正生效，整张表被渲染成一行裸竖线文本。`rehype-raw` 未启用，inline HTML `<table>` 也会被剥光，所以转 HTML 不可行。bullet list 是当前唯一在 quay 可靠展示的形态。

dockerhub 的渲染器对 GFM 表格正常，所以保留原文走 dockerhub 路径。

实测过程：
- 用 OAuth token 调 `PUT /api/v1/repository/ascend/ragsdk` 推转换后的内容，HTTP 200。
- 浏览器在 https://quay.io/repository/ascend/ragsdk?tab=info 上刷新，三段表格已经按"标题行 + bullet"形态正确显示。

## Test plan

- [ ] Repo Settings → Secrets 已新增 `QUAY_API_KEY`（Administer Repositories scope OAuth token）
- [ ] 触发一次 `workflow_dispatch`，确认日志里 `quay.io/ascend/ragsdk` 这条 `✅ synced`
- [ ] 浏览器看 https://quay.io/repository/ascend/ragsdk?tab=info ，三张表都是 bullet 形态
- [ ] 第二次触发同 workflow，应该看到 `⏭️  skip (unchanged, ...)` 验证 cache 命中

## Notes

- 旧 secrets `QUAY_API_TOKEN` / `QUAY_ASCEND_PWD` 对此 workflow 已不再使用，可以视情况清理（但其他 workflow 仍可能依赖 `QUAY_ASCEND_PWD` 做 docker login，建议先 grep 确认）。
- 转换器目前只处理 pipe table，其它语法原样透传。