### PR TITLE
fix(quay-md-adapt): keep links clickable, code-block tables otherwise

### DIFF
--- a/.github/scripts/quay_md_adapt.py
+++ b/.github/scripts/quay_md_adapt.py
@@ -3,15 +3,24 @@
 
 quay.io's Information tab uses react-markdown, but the deployed build does not
 render GFM pipe tables — they collapse onto one line as literal text. Inline
-HTML <table> tags are also stripped because rehype-raw is not enabled. The only
-form that renders reliably is a plain bullet list, so we rewrite each pipe
-table to "*<header line>*" followed by one bullet per row.
+HTML <table> tags are also stripped because rehype-raw is not enabled.
+
+For each pipe table we pick the form that preserves the most information:
+
+- If any cell contains a markdown link, render the table as a bullet list with
+  inline-code padding so the first column still aligns visually while links
+  remain clickable.
+- Otherwise, render as a fenced code block — quay shows code blocks in a
+  monospace font, so columns line up cleanly.
 
 Usage: quay_md_adapt.py <input.md> <output.md>
 """
 import re
 import sys
+import unicodedata
 import pathlib
+
+LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 
 def parse_row(line: str) -> list[str]:
@@ -20,7 +29,7 @@ def parse_row(line: str) -> list[str]:
         s = s[1:]
     if s.endswith("|"):
         s = s[:-1]
-    return [c.strip() for c in re.split(r"(?<!\\)\|", s)]
+    return [c.strip().replace("\\|", "|") for c in re.split(r"(?<!\\)\|", s)]
 
 
 def is_separator(line: str) -> bool:
@@ -31,22 +40,72 @@ def is_separator(line: str) -> bool:
     return bool(cells) and all(re.fullmatch(r":?-{3,}:?", c) for c in cells)
 
 
-def render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
-    headers = [h for h in headers if h]
-    if not headers:
-        return []
-    out = ["*" + " — ".join(headers) + "*", ""]
-    for row in rows:
-        cells = (row + [""] * len(headers))[: len(headers)]
-        if not any(cells):
+def display_width(s: str) -> int:
+    width = 0
+    for ch in s:
+        if unicodedata.combining(ch):
             continue
-        first, rest = cells[0], [c for c in cells[1:] if c]
-        line = f"- **{first}**" if first else "-"
+        width += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return width
+
+
+def has_link(rows: list[list[str]]) -> bool:
+    return any(LINK_RE.search(cell) for row in rows for cell in row)
+
+
+def render_codeblock(headers: list[str], rows: list[list[str]]) -> list[str]:
+    n = len(headers)
+    widths = [display_width(h) for h in headers]
+    for r in rows:
+        for i, c in enumerate(r):
+            widths[i] = max(widths[i], display_width(c))
+
+    def fmt(cells: list[str]) -> str:
+        return " | ".join(
+            cells[i] + " " * (widths[i] - display_width(cells[i]))
+            for i in range(n)
+        ).rstrip()
+
+    sep = "-+-".join("-" * w for w in widths)
+    out = ["", "```", fmt(headers), sep]
+    out.extend(fmt(r) for r in rows)
+    out.append("```")
+    out.append("")
+    return out
+
+
+def render_bullets(headers: list[str], rows: list[list[str]]) -> list[str]:
+    def first_col_width(cell: str) -> int:
+        return display_width(LINK_RE.sub(r"\1", cell))
+
+    pad = max((first_col_width(r[0]) for r in rows), default=0)
+    out = ["", f"**{' / '.join(headers)}**", ""]
+    for r in rows:
+        first = r[0]
+        rest = [c for c in r[1:] if c]
+        first_padded = first + " " * (pad - first_col_width(first))
+        if LINK_RE.search(first):
+            line = f"- {first_padded}"
+        else:
+            line = f"- `{first_padded}`"
         if rest:
             line += " — " + " — ".join(rest)
         out.append(line)
     out.append("")
     return out
+
+
+def render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    headers = [h for h in headers if h]
+    if not headers:
+        return []
+    n = len(headers)
+    norm = [(r + [""] * n)[:n] for r in rows if any(r)]
+    if not norm:
+        return []
+    if has_link(norm):
+        return render_bullets(headers, norm)
+    return render_codeblock(headers, norm)
 
 
 def convert(md: str) -> str:


### PR DESCRIPTION
## Summary

让 quay 同步器按 **每张表的内容** 选渲染形态：

- 含 `[text](url)` 的表 → bullet 列表，第一列用 inline code 等宽对齐，链接保留可点
- 不含链接的表 → fenced 代码块（quay 的代码块走等宽字体，列天然对齐）

之前合入 #16 时只带了"全部转 bullet 单行列表"那一版，列对不齐。这个 PR 是 follow-up，补齐当时本应一起进来的混合策略。

## Why

quay.io Information tab 的 react-markdown 部署版本对 GFM pipe table 没有真正生效，整张表会被压成一行裸竖线文本；`rehype-raw` 也未启用，所以 inline HTML `<table>` 同样被剥光。在它支持的语法里：

- 代码块 → 列对齐效果最好，**但里面的 `[text](url)` 是字面文本**
- bullet 列表 → 链接可点击，**但靠 inline code + 空格对第一列做视觉对齐**

所以两种策略都需要，按表内容自动选。

## Test plan

- [x] 本地用真实的 `docker/OVERVIEW.md` 跑过转换器，三张表分类符合预期：
  - "Tag Naming Convention" / "Supported Hardware" → 代码块对齐
  - "RAGSDK 26.0.0"（含 `[Dockerfile](...)`）→ bullet + inline code，链接可点
- [x] 本地把转换后的 markdown PUT 到 quay 实测渲染正确
- [ ] merge 后等下一次 sync 跑通，刷新 https://quay.io/repository/ascend/ragsdk?tab=info 验证

## Notes

- 不影响 dockerhub 路径（GFM 表格在 dockerhub 上正常渲染，那条链路继续用原文）。
- "RAGSDK 26.0.0" 表里的 Dockerfile 链接当前在源 `OVERVIEW.md` 里写的是相对路径 `./Dockerfile.310p.ubuntu`，在 quay 上点击会跳到死链。要真能用，需要在 gitcode 源仓库改成绝对 URL（这是 README 内容的事，不属于本 PR 范围）。