### PR TITLE
chore: align cluster names with deployed runners and add verl

### DIFF
--- a/.github/workflows/config/projects-clusters.json
+++ b/.github/workflows/config/projects-clusters.json
@@ -1,9 +1,12 @@
 {
   "vllm": {
-    "clusters": ["linux-amd64-vllm-guiyang003"]
+    "clusters": ["linux-amd64-vllm-a2", "linux-amd64-vllm-a3"]
   },
   "sglang": {
-    "clusters": ["linux-amd64-sglang-guiyang004", "linux-amd64-sglang-sglang01"]
+    "clusters": ["linux-amd64-sglang-a2", "linux-amd64-sglang-a3"]
+  },
+  "verl": {
+    "clusters": ["linux-amd64-verl-a3"]
   },
   "ms-swift": {
     "clusters": ["linux-aarch64-sync-hk001"]

--- a/.github/workflows/config/projects/verl.json
+++ b/.github/workflows/config/projects/verl.json
@@ -1,0 +1,16 @@
+{
+  "models": [
+    {
+      "platform": "modelscope",
+      "organization": "Qwen",
+      "model_name": "Qwen2.5-0.5B-Instruct"
+    }
+  ],
+  "datasets": [
+    {
+      "platform": "modelscope",
+      "organization": "AI-ModelScope",
+      "dataset_name": "gsm8k"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Align `projects-clusters.json` with the runner labels actually deployed on hk001, and add **verl** as a new project (also bound to a new dedicated runner).

| Project | Runners |
|---|---|
| vllm | `linux-amd64-vllm-a2`, `linux-amd64-vllm-a3` |
| sglang | `linux-amd64-sglang-a2`, `linux-amd64-sglang-a3` |
| verl | `linux-amd64-verl-a3` (new) |
| ms-swift | `linux-aarch64-sync-hk001` (unchanged) |
| llamafactory | `linux-aarch64-sync-hk001` (unchanged) |

Previous labels (`linux-amd64-vllm-guiyang003`, `linux-amd64-sglang-guiyang004`, `linux-amd64-sglang-sglang01`) were placeholders carried over from the legacy workflow naming and never had real runners attached. They are now replaced with the real ARC RunnerScaleSet labels.

## Files

- `.github/workflows/config/projects-clusters.json` — runner names updated; `verl` added
- `.github/workflows/config/projects/verl.json` — minimal first entry (one HF model, one MS dataset placeholder), so verl team can self-serve from here on

## Local validation

- All JSON files parse cleanly
- `test.yml` schema checks pass (every project key has a matching `config/projects/<name>.json` with `models` and `datasets` arrays)
- `build-sync-matrix.sh` (schedule path) expands to 7 jobs:
  ```
  llamafactory -> linux-aarch64-sync-hk001
  ms-swift     -> linux-aarch64-sync-hk001
  sglang       -> linux-amd64-sglang-a2
  sglang       -> linux-amd64-sglang-a3
  verl         -> linux-amd64-verl-a3
  vllm         -> linux-amd64-vllm-a2
  vllm         -> linux-amd64-vllm-a3
  ```

## Test plan

- [ ] After merge, manually dispatch `sync models and datasets` with `project: vllm` — should fan out to a2 + a3 in parallel; both succeed
- [ ] Same with `project: sglang` — fan out to a2 + a3
- [ ] Same with `project: verl` — single job on verl-a3, downloads the placeholder model+dataset
- [ ] Re-run any of the above; SDKs should hit `/root/.cache` and skip downloads
