### PR TITLE
fix: add swr.cn-east-3 credentials in get_creds()

### DIFF
--- a/.github/workflows/sync-images.yml
+++ b/.github/workflows/sync-images.yml
@@ -62,6 +62,7 @@ jobs:
               quay.io/*)              echo "${QUAY_ASCEND_USER}:${QUAY_ASCEND_PWD}" ;;
               docker.io/*)            echo "${DOCKERHUB_USER}:${DOCKERHUB_PWD}" ;;
               swr.cn-southwest-2.*)   echo "${HWCLOUD_USER}:${HWCLOUD_PWD}" ;;
+              swr.cn-east-3.*)        echo "${HWCLOUD_USER}:${HWCLOUD_PWD}" ;;
               swr.ap-southeast-1.*)   echo "${SWR_HK_USER}:${SWR_HK_SECRET}" ;;
               *)                      echo "" ;;
             esac


### PR DESCRIPTION
## Summary

- `get_creds()` 缺少 `swr.cn-east-3.*` 的 case，导致同步到华东 SWR 时凭证为空，认证失败（`invalid username/password: denied: You may not login yet`）
- 新增一行复用已有的 `HWCLOUD_USER`/`HWCLOUD_PWD`，与西南区保持一致，无需新增 secret

## Root Cause

Job [79463548247](https://github.com/ascend-gha-runners/sync-tools/actions/runs/26935312731/job/79463548247) 对 `swr.cn-east-3.myhuaweicloud.com/upupup/ascend-ci/vllm-ascend/vllm-ascend` 同步时，`get_creds()` 命中了 `*` 通配符返回空字符串，导致 201 个 tag 全部认证失败。

## Test plan

- [ ] 触发一次 `Sync quay.io/ascend/vllm-ascend` job，确认华东 SWR 目标不再报认证错误