### PR TITLE
fix: use dedicated credentials for swr.cn-east-3

### DIFF
--- a/.github/workflows/sync-images.yml
+++ b/.github/workflows/sync-images.yml
@@ -53,6 +53,8 @@ jobs:
           DOCKERHUB_PWD: ${{ secrets.DOCKERHUB_PWD }}
           HWCLOUD_USER: ${{ vars.HWCLOUD_USER }}
           HWCLOUD_PWD: ${{ secrets.HWCLOUD_PWD }}
+          SWR_EAST3_USER: ${{ vars.SWR_EAST3_USER }}
+          SWR_EAST3_SECRET: ${{ secrets.SWR_EAST3_SECRET }}
           SWR_HK_USER: ${{ vars.REGISTRY_HK_USER }}
           SWR_HK_SECRET: ${{ secrets.SWR_HK_SECRET }}
           CURRENT_SRC: ${{ matrix.src }}
@@ -62,7 +64,7 @@ jobs:
               quay.io/*)              echo "${QUAY_ASCEND_USER}:${QUAY_ASCEND_PWD}" ;;
               docker.io/*)            echo "${DOCKERHUB_USER}:${DOCKERHUB_PWD}" ;;
               swr.cn-southwest-2.*)   echo "${HWCLOUD_USER}:${HWCLOUD_PWD}" ;;
-              swr.cn-east-3.*)        echo "${HWCLOUD_USER}:${HWCLOUD_PWD}" ;;
+              swr.cn-east-3.*)        echo "${SWR_EAST3_USER}:${SWR_EAST3_SECRET}" ;;
               swr.ap-southeast-1.*)   echo "${SWR_HK_USER}:${SWR_HK_SECRET}" ;;
               *)                      echo "" ;;
             esac


### PR DESCRIPTION
## Summary

- 华东 SWR (`swr.cn-east-3`) 需要独立的账号凭证，不能复用西南区的 `HWCLOUD_USER/HWCLOUD_PWD`
- 新增环境变量 `SWR_EAST3_USER`（var）和 `SWR_EAST3_SECRET`（secret），在 `get_creds()` 中单独处理 `swr.cn-east-3.*`

## Action Required

合并后需要在仓库 Settings 中配置：
- **Variables**: `SWR_EAST3_USER` = 华东 SWR 登录用户名（格式：`cn-east-3@<AK>`）
- **Secrets**: `SWR_EAST3_SECRET` = 对应的登录密钥

## Test plan

- [ ] 配置好 `SWR_EAST3_USER` / `SWR_EAST3_SECRET` 后触发一次 `Sync quay.io/ascend/vllm-ascend`，确认华东 SWR 目标认证通过