### PR TITLE
fix: use hf-mirror.com for HuggingFace downloads on restricted runners

### DIFF
--- a/.github/scripts/download-json-models.sh
+++ b/.github/scripts/download-json-models.sh
@@ -35,6 +35,7 @@ jq -c '.[]' "$CONFIG_FILE" | while IFS= read -r entry; do
     [ -n "$local_dir" ] && ms_args+=(--local_dir "$local_dir")
     modelscope download "${ms_args[@]}" || echo "WARNING: Failed to download $TYPE $organization/$name from ModelScope"
   elif [ "$platform" = "huggingface" ]; then
+    export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
     if [ "$TYPE" = "model" ]; then
       if [ -n "$local_dir" ]; then
         python -c "from huggingface_hub import snapshot_download; snapshot_download(repo_id='$organization/$name', local_dir='$local_dir')" || echo "WARNING: Failed to download model $organization/$name from HuggingFace"


### PR DESCRIPTION
## Summary

- Runners in certain network environments (e.g. `linux-amd64-hb003-omni`) cannot reach `huggingface.co` directly, causing all HuggingFace downloads to fail with `ConnectError: [Errno 101] Network is unreachable`
- In the affected run, 6 models silently failed: `jeeejeee/llama32-3b-text2sql-spider`, `meta-llama/Llama-3.2-3B-Instruct`, `meta-llama/Meta-Llama-3-8B`, `charent/self_cognition_Alice`, `charent/self_cognition_Bob`, `Qwen/Qwen3.5-0.8B`
- Each failed download wasted ~2 minutes waiting for timeout before moving on

## Fix

Set `HF_ENDPOINT` to `https://hf-mirror.com` before any HuggingFace download. The variable uses `${HF_ENDPOINT:-https://hf-mirror.com}` so callers can still override it if needed (e.g. runners that can reach HF directly).

## Test plan

- [ ] Verify `vllm-omni` sync job on `linux-amd64-hb003-omni` runner successfully downloads all 6 HuggingFace models
- [ ] Verify other jobs unaffected (only `platform: "huggingface"` entries are affected)

Ref: https://github.com/ascend-gha-runners/sync-tools/actions/runs/27101939880/job/79984137686